### PR TITLE
Fixed broken links to w3c-test.org (specs and test suites)

### DIFF
--- a/data/animation-timing.json
+++ b/data/animation-timing.json
@@ -12,7 +12,7 @@
       "id" : "animation-timing"
    },
    "editors" : {
-      "url" : "http://w3c-test.org/webperf/specs/RequestAnimationFrame/"
+      "url" : "https://dvcs.w3.org/hg/webperf/raw-file/tip/specs/RequestAnimationFrame/Overview.html"
    },
    "TR" : "http://www.w3.org/TR/animation-timing/",
    "stability" : {

--- a/data/audio.json
+++ b/data/audio.json
@@ -7,7 +7,7 @@
    "tests" : {
       "level" : "low",
       "repo" : "https://github.com/w3c/web-platform-tests/",
-      "url" : "http://w3c-test.org/html/semantics/embedded-content-0/the-audio-element",
+      "url" : "http://w3c-test.org/html/semantics/embedded-content/the-audio-element",
       "label" : "Started"
    },
    "impl" : {

--- a/data/canvasproxy.json
+++ b/data/canvasproxy.json
@@ -11,9 +11,9 @@
       "id" : "canvasproxy"
    },
    "editors" : {
-      "url" : "http://www.w3.org/html/wg/drafts/html/master/embedded-content-0.html#proxying-canvases-to-workers"
+      "url" : "http://www.w3.org/html/wg/drafts/html/master/scripting-1.html#proxying-canvases-to-workers"
    },
-   "TR" : "http://www.w3.org/TR/html51/embedded-content-0.html#proxying-canvases-to-workers",
+   "TR" : "http://www.w3.org/TR/html51/scripting-1.html#proxying-canvases-to-workers",
    "stability" : {
       "level" : "low",
       "label" : "Early draft"

--- a/data/discovery.json
+++ b/data/discovery.json
@@ -11,7 +11,7 @@
       "id" : "discovery"
    },
    "editors" : {
-      "url" : "http://w3c-test.org/dap/discovery-api/"
+      "url" : "https://dvcs.w3.org/hg/dap/raw-file/tip/discovery-api/Overview.html"
    },
    "TR" : "http://www.w3.org/TR/discovery-api/",
    "stability" : {

--- a/data/filereader.json
+++ b/data/filereader.json
@@ -3,7 +3,7 @@
    "tests" : {
       "level" : "low",
       "repo" : "https://github.com/w3c/web-platform-tests/",
-      "url" : "http://w3c-test.org/FileAPI/tests/",
+      "url" : "http://w3c-test.org/FileAPI/",
       "label" : "Started"
    },
    "impl" : {

--- a/data/inputdate.json
+++ b/data/inputdate.json
@@ -15,9 +15,9 @@
       "label" : "Growing",
       "id" : "inputdate"
    },
-   "TR" : "http://www.w3.org/TR/html5/forms.html#date-and-time-state-(type=datetime)",
+   "TR" : "http://www.w3.org/TR/html5/forms.html#date-state-(type=date)",
    "editors" : {
-      "url" : "http://www.w3.org/html/wg/drafts/html/CR/forms.html#date-and-time-state-(type=datetime)"
+      "url" : "http://www.w3.org/html/wg/drafts/html/CR/forms.html#date-state-(type=date)"
    },
    "wdc" : {
       "url" : "http://www.w3devcampus.com/html5-w3c-training/",

--- a/data/notification.json
+++ b/data/notification.json
@@ -5,10 +5,6 @@
       "url" : "http://w3c-test.org/notifications/",
       "label" : "None"
    },
-   "wpd" : {
-      "url" : "http://docs.webplatform.org/wiki/tutorials/notifications_api",
-      "label" : "Notification API tutorial"
-   },
    "impl" : {
       "level" : "medium",
       "label" : "Growing deployment",

--- a/data/setimmediate.json
+++ b/data/setimmediate.json
@@ -20,7 +20,7 @@
    "title" : "Efficient Script Yielding",
    "TR" : "",
    "editors" : {
-      "url" : "http://w3c-test.org/webperf/specs/setImmediate/"
+      "url" : "https://dvcs.w3.org/hg/webperf/raw-file/tip/specs/setImmediate/Overview.html"
    },
    "stability" : {
       "level" : "low",

--- a/data/touchevent.json
+++ b/data/touchevent.json
@@ -7,7 +7,7 @@
    "tests" : {
       "level" : "high",
       "repo" : "",
-      "url" : "http://w3c-test.org/webevents/tests/touch-events-v1/",
+      "url" : "http://w3c-test.org/touch-events/",
       "label" : "Complete"
    },
    "impl" : {

--- a/data/video.json
+++ b/data/video.json
@@ -7,7 +7,7 @@
    "tests" : {
       "level" : "medium",
       "repo" : "https://github.com/w3c/web-platform-tests/",
-      "url" : "http://w3c-test.org/html/semantics/embedded-content-0/the-video-element/",
+      "url" : "http://w3c-test.org/html/semantics/embedded-content/the-video-element/",
       "label" : "Well started"
    },
    "impl" : {


### PR DESCRIPTION
A number of specifications and test suites got moved to different folders on `w3c-test.org`. This commit should fix all broken links that appear in the final roadmap.

As an exception to the rule, I could not find the tests referenced by the `inputaccept.json` file for the Media Capture specification. I see there's an on-going pull request at:
  `https://github.com/w3c/web-platform-tests/pull/306`
... but files do not appear under `http://w3c-test.org/submissions`. The broken link remains.

Not related but note the notifications API tutorial is no longer available on `WebPlatform.org` so I dropped the section from the `notification.json` file.
